### PR TITLE
Fix list go version bug

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/manifoldco/promptui"
 	"github.com/sirupsen/logrus"
@@ -76,7 +77,7 @@ func goupVersionDir(ver string) string {
 }
 
 func goupVersionBinGoExec(ver string) string {
-	return GoupDir(ver, "bin", "go")
+	return GoupDir(ver, "bin", "go"+exe())
 }
 
 func GoupDir(paths ...string) string {
@@ -136,4 +137,11 @@ func runChooseVersion(cmd *cobra.Command, args []string) error {
 	logger.Printf("Default Go is set to '%s'", ver)
 
 	return nil
+}
+
+func exe() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -75,6 +75,10 @@ func goupVersionDir(ver string) string {
 	return GoupDir(ver)
 }
 
+func goupVersionBinGoExec(verDir string) string {
+	return GoupDir(verDir, "bin", "go")
+}
+
 func GoupDir(paths ...string) string {
 	elem := []string{homedir, ".go"}
 	elem = append(elem, paths...)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -75,8 +75,8 @@ func goupVersionDir(ver string) string {
 	return GoupDir(ver)
 }
 
-func goupVersionBinGoExec(verDir string) string {
-	return GoupDir(verDir, "bin", "go")
+func goupVersionBinGoExec(ver string) string {
+	return GoupDir(ver, "bin", "go")
 }
 
 func GoupDir(paths ...string) string {

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -79,6 +79,10 @@ func listGoVers() ([]goVer, error) {
 	var vers []goVer
 	for _, file := range files {
 		if strings.HasPrefix(file.Name(), "go") {
+			err := exec.Command(goupVersionBinGoExec(file.Name()), "version").Run()
+			if err != nil {
+				continue
+			}
 			vers = append(vers, goVer{
 				Ver:     strings.TrimPrefix(file.Name(), "go"),
 				Current: current == file.Name(),

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -78,14 +78,14 @@ func listGoVers() ([]goVer, error) {
 
 	var vers []goVer
 	for _, file := range files {
-		if strings.HasPrefix(file.Name(), "go") {
-			err := exec.Command(goupVersionBinGoExec(file.Name()), "version").Run()
+		if filename := file.Name(); strings.HasPrefix(filename, "go") {
+			err := exec.Command(goupVersionBinGoExec(filename), "version").Run()
 			if err != nil {
 				continue
 			}
 			vers = append(vers, goVer{
-				Ver:     strings.TrimPrefix(file.Name(), "go"),
-				Current: current == file.Name(),
+				Ver:     strings.TrimPrefix(filename, "go"),
+				Current: current == filename,
 			})
 		}
 	}


### PR DESCRIPTION
when use `goup install` install a go version,if it interrupt by user, it will create a folder under ".go", but it's a invalid go version. 
so when list go version, use "go version" command to filter invalid go version.

Hoping add the features:
    `goup clean`  clean invalid go versions