### PR TITLE
feat: Rename goup default to goup set

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ $ GOUP_GO_HOST=golang.google.cn goup install # For Gophers in China, see https:/
 
 * `install.sh` downloads the latest Goup release for your platform and appends Goup's bin directory (`$HOME/.go/bin`) & Go's bin directory (`$HOME/.go/current/bin`) to your PATH environment variable.
 * `goup` switches to selected Go version.
-* `goup default` switches to selected Go version.
+* `goup set` switches to selected Go version.
 * `goup install` downloads specified version of Go to`$HOME/.go/VERSION` and symlinks it to `$HOME/.go/current`.
 * `goup show` shows the activated Go version located at `$HOME/.go/current`.
 * `goup remove` removes the specified Go version.

--- a/ftest/ftest_test.go
+++ b/ftest/ftest_test.go
@@ -113,8 +113,8 @@ func TestGoup(t *testing.T) {
 		}
 	})
 
-	t.Run("goup default 1.15.2", func(t *testing.T) {
-		cmd := exec.Command(goupBin, "default", "1.15.2")
+	t.Run("goup set 1.15.2", func(t *testing.T) {
+		cmd := exec.Command(goupBin, "set", "1.15.2")
 		execCmd(t, cmd)
 	})
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -43,7 +43,7 @@ func NewCommand() *cobra.Command {
 	rootCmd.PersistentFlags().BoolVarP(&rootCmdVerboseFlag, "verbose", "v", false, "Verbose")
 
 	rootCmd.AddCommand(installCmd())
-	rootCmd.AddCommand(defaultCmd())
+	rootCmd.AddCommand(setCmd())
 	rootCmd.AddCommand(removeCmd())
 	rootCmd.AddCommand(initCmd())
 	rootCmd.AddCommand(showCmd())

--- a/internal/commands/set.go
+++ b/internal/commands/set.go
@@ -5,21 +5,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func defaultCmd() *cobra.Command {
+func setCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "default <VERSION>...",
+		Use:   "set <VERSION>...",
 		Short: "Set the default Go version",
 		Long: `Set the default Go version to one specified. If no version is provided,
 a prompt will show to select a installed Go version.`,
 		Example: `
-  goup default # A prompt will show to select a version
-  goup default 1.15.2
+  goup set # A prompt will show to select a version
+  goup set 1.15.2
 `,
-		RunE: runDefault,
+		RunE: runSetDefault,
 	}
 }
 
-func runDefault(cmd *cobra.Command, args []string) error {
+func runSetDefault(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		return switchVer(args[0])
 	}


### PR DESCRIPTION
the end.
```sh
Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  install     Install Go with a version
  ls          List all installed Go
  remove      Remove Go with a version
  search      Search Go versions to install
  set         Set the default Go version
  upgrade     Upgrade goup
  version     Show goup version

Flags:
  -h, --help      help for goup
  -v, --verbose   Verbose
```