### PR TITLE
fix: can't install go1.21.0 because of parse latest version failed

### DIFF
--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"archive/tar"
 	"archive/zip"
+	"bufio"
 	"compress/gzip"
 	"crypto/sha256"
 	"errors"
@@ -127,12 +128,12 @@ func latestGoVersion() (string, error) {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return "", fmt.Errorf("Could not get current Go version: HTTP %d: %q", resp.StatusCode, b)
 	}
-	version, err := io.ReadAll(resp.Body)
+	version, err := bufio.NewReader(resp.Body).ReadString('\n')
 	if err != nil {
 		return "", err
 	}
 
-	return strings.TrimSpace(string(version)), nil
+	return strings.TrimSpace(version), nil
 }
 
 func switchVer(ver string) error {


### PR DESCRIPTION
https://go.dev/VERSION?m=text now return with timestamp:

```
go1.21.0
time 2023-08-04T20:14:06Z
```

so, executing `goup install` will failed.

this PR  fixed it~